### PR TITLE
Added support for more messages, fixed escaping bug, other minor fixes

### DIFF
--- a/log_structure.md
+++ b/log_structure.md
@@ -1,37 +1,37 @@
-# MBB log file layout 
+# MBB log file layout
 
 *note: values in raw logs are little endian*
 
 ## Static addresses
 
-Address    | Length | Contents                                      
+Address    | Length | Contents
 ---------- | :----: | --------
 0x00000200 | 21     | Serial number
 0x00000240 | 17     | VIN number
 0x0000027b | 1      | Firmware revision
 0x0000027d | 1      | Board revision
-0x0000027f | 2      | Bike model (`SS`, `SR`, `DS`, *FX?*)
+0x0000027f | 3      | Bike model (`SS`, `SR`, `DS`, *FX?*)
 
 
 ## Log sections (located by header sequence)
 
 ### Unknown *(build date?)*
 
-Offset     | Length | Contents                                      
+Offset     | Length | Contents
 ---------- | :----: | --------
 0x00000000 | 4      | `0xa0 0xa0 0xa0 0xa0` section header
 0x00000004 | 20     | Date and time (ascii)
 
 ### Unknown *(first run date?)*
 
-Offset     | Length | Contents                                      
+Offset     | Length | Contents
 ---------- | :----: | --------
 0x00000000 | 4      | `0xa1 0xa1 0xa1 0xa1` section header
 0x00000004 | 20     | Date and time (ascii)
 
 ### Event Log
 
-Offset     | Length     | Contents                                      
+Offset     | Length     | Contents
 ---------- | :--------: | --------
 0x00000000 | 4          | `0xa2 0xa2 0xa2 0xa2` section header
 0x00000004 | 4          | Log entries end address
@@ -41,7 +41,7 @@ Offset     | Length     | Contents
 
 ### Error Log
 
-Offset     | Length     | Contents                                      
+Offset     | Length     | Contents
 ---------- | :--------: | --------
 0x00000000 | 4          | `0xa3 0xa3 0xa3 0xa3` section header
 0x00000004 | 4          | Log entries end address
@@ -52,7 +52,7 @@ Offset     | Length     | Contents
 
 # BMS log file layout (*WIP*)
 
-Address    | Length | Contents                                      
+Address    | Length | Contents
 ---------- | :----: | --------
 0x00000000 | 3      | `BMS`
 0x0000000e | 4      | `0xa1 0xa1 0xa1 0xa1` *(header / seperator?)*
@@ -68,7 +68,7 @@ Address    | Length | Contents
 
 # Log entry format (shared by MBB and BMS)
 
-Offset | Length    | Contents                                      
+Offset | Length    | Contents
 ------ | :-------: | --------
 0x00   | 1         | `0xb2` Entry header
 0x01   | 1         | Entry length (including header byte)
@@ -76,26 +76,42 @@ Offset | Length    | Contents
 0x03   | 4         | Timestamp (epoch)
 0x07   | *variabe* | Entry data
 
+Note that the entry appears to be encoded in some format starting from the entry type onwards (ie Entry type, timestamp, Entry data). Any bytes of 0xFE are xor'ed with the next byte -1.
+
+For example, the byte sequenze 0xFE, 0x01 becomes 0xFE. The byte sequence OxFE, 0x4d becomes 0xb2. The length of the message is reduced accordingly.
+
 ## Log file entry types
 
+### `0x0` - board status
+Offset | Length | Contents
+------ | :----: | --------
+0x00   | 1      | cause of reset
+
+This is still WIP as there aren't many messages available
+
 ### `0x09` - key state
-Offset | Length | Contents                                      
+Offset | Length | Contents
 ------ | :----: | --------
 0x00   | 1      | state
 
 ### `0x28` - battery CAN link up
-Offset | Length | Contents                                      
+Offset | Length | Contents
+------ | :----: | --------
+0x00   | 1      | module number
+
+### `0x29` - battery CAN link down
+Offset | Length | Contents
 ------ | :----: | --------
 0x00   | 1      | module number
 
 ### `0x2a` - Sevcon CAN link up
 *(no additional data)*
 
-### `0x2b` -CAN ACK error
+### `0x2b` - Sevcon CAN link down
 *(no additional data)*
 
 ### `0x2c` - Riding / run status
-Offset | Length | Contents                                      
+Offset | Length | Contents
 ------ | :----: | --------
 0x00   | 1      | pack temp (high)
 0x01   | 1      | pack temp (low)
@@ -104,13 +120,43 @@ Offset | Length | Contents
 0x08   | 1      | motor temp
 0x0a   | 1      | controller temp
 0x0c   | 2      | motor RPM
-0x10   | 1      | battery current
-0x13   | 1      | motor current
+0x10   | 2      | battery current
+0x12   | 1      | mods (??)
+0x13   | 2      | motor current
+0x15   | 2      | ambient temperature
+0x17   | 4      | odometer
 
 *note: all temperatures in degrees celcius*
 
+### `0x2d` - Charging status
+Offset | Length | Contents
+------ | :----: | --------
+0x00   | 1      | pack temp (high)
+0x01   | 1      | pack temp (low)
+0x02   | 2      | pack state of charge (%)
+0x04   | 4      | pack voltage - fixed point, scaling factor 1/1000
+0x08   | 1      | battery current
+0x0c   | 1      | mods (??)
+0x0d   | 2      | ambient temperature
+
+*note: all temperatures in degrees celcius*
+
+### `0x2f` - sevcon status
+Offset | Length | Contents
+------ | :----: | --------
+0x00   | 2      | error code
+0x02   | 2      | sevcon error code
+0x04   | 1      | error reg
+0x05   | 1+     | error data
+
+### `0x30` - charger status
+Offset | Length | Contents
+------ | :----: | --------
+0x00   | 1      | Module type
+0x01   | 1      | Module state
+
 ### `0x33` - battery status
-Offset | Length | Contents                                      
+Offset | Length | Contents
 ------ | :----: | --------
 0x00   | 1      | `0x00`=disconnecting, `0x01`=connecting, `0x02`=registered
 0x01   | 1      | module number
@@ -119,29 +165,57 @@ Offset | Length | Contents
 0x0a   | 4      | minimum system voltage - fixed point, scaling factor 1/1000
 
 ### `0x34` - power state
-Offset | Length | Contents                                      
+Offset | Length | Contents
 ------ | :----: | --------
 0x00   | 1      | state
 0x01   | 1      | `0x01`=key switch, `0x04`=onboard charger
 
 ### `0x36` - Sevcon power state
-Offset | Length | Contents                                      
+Offset | Length | Contents
 ------ | :----: | --------
 0x00   | 1      | state
 
+### `0x38` - bluetooth state
+*(no additional data)*
+
 ### `0x39` - battery discharge current limited
-Offset | Length | Contents                                      
+Offset | Length | Contents
 ------ | :----: | --------
 0x00   | 2      | discharge current
 
+### `0x3a` - Low Chassis isolation
+Offset | Length | Contents
+------ | :----: | --------
+0x00   | 4      | kOhms of isolation
+0x04   | 1      | Cell affected
+
+### `0x3b` - precharge decay too steep
+*(no additional data)*
+
+### `0x3c` - disarmed status
+Offset | Length | Contents
+------ | :----: | --------
+0x00   | 1      | pack temp (high)
+0x01   | 1      | pack temp (low)
+0x02   | 2      | pack state of charge (%)
+0x04   | 4      | pack voltage - fixed point, scaling factor 1/1000
+0x08   | 2      | motor temp
+0x0a   | 2      | controller temp
+0x0c   | 2      | motor RPM
+0x10   | 2      | battery current
+0x12   | 1      | mods (??)
+0x13   | 2      | motor current
+0x15   | 2      | ambient temperature
+0x17   | 4      | odometer
+
 ### `0x3d` - battery module contactor closed
-Offset | Length | Contents                                      
+Offset | Length | Contents
 ------ | :----: | --------
 0x00   | 1      | module number
 
 ### `0x3e` - *cell voltages?*
 
 ### `0xfd` - debug string
-Offset | Length     | Contents                                      
+Offset | Length     | Contents
 ------ | :--------: | --------
 0x00   | *variable* | message text (ascii)

--- a/zero_log_parser.py
+++ b/zero_log_parser.py
@@ -17,9 +17,28 @@ import argparse
 import os
 import mmap
 import struct
-from time import localtime, strftime
+import string
+from time import localtime, strftime, gmtime
 from collections import OrderedDict
 
+TRADITIONAL_FORMAT = {
+        'logline': '{entry:05d}  {time:19s}  {message}\n',
+        'time_format': '%Y-%m-%d %H:%M:%S',
+        'disarmed_format': 'Disarmed - pack: h {pack_temp_hi}C, l {pack_temp_low}C, {pack_voltage:03.3f}V, {soc}% SOC | motor: {motor_temp}C, {rpm}rpm | controller: {controller_temp}C, | power delivery: battery {battery_current}A, motor {motor_current}A',
+        'riding_format': 'Riding - pack: h {pack_temp_hi}C, l {pack_temp_low}C, {pack_voltage:03.3f}V, {soc}% SOC | motor: {motor_temp}C, {rpm}rpm | controller: {controller_temp}C, | power delivery: battery {battery_current}A, motor {motor_current}A',
+        'power_format': 'Power {state} ({source})',
+    }
+
+OFFICIAL_FORMAT = {
+        'logline': ' {entry:05d}     {time:>19s}   {message}\n',
+        'time_format': '%m/%d/%Y %H:%M:%S',
+        'disarmed_format': 'Disarmed                   PackTemp: h {pack_temp_hi}C, l {pack_temp_low}C, PackSOC:{soc:3d}%, Vpack:{pack_voltage:03.3f}V, MotAmps:{motor_current:4d}, BattAmps:{battery_current:4d}, Mods: {mods:02b}, MotTemp:{motor_temp:4d}C, CtrlTemp:{controller_temp:4d}C, AmbTemp:{ambient_temp:4d}C, MotRPM:{rpm:4d}, Odo:{odometer:5d}km',
+        'riding_format': 'Riding                     PackTemp: h {pack_temp_hi}C, l {pack_temp_low}C, PackSOC:{soc:3d}%, Vpack:{pack_voltage:7.3f}V, MotAmps:{motor_current:4d}, BattAmps:{battery_current:4d}, Mods: {mods}, MotTemp:{motor_temp:4d}C, CtrlTemp:{controller_temp:4d}C, AmbTemp:{ambient_temp:4d}C, MotRPM:{rpm:4d}, Odo:{odometer:5d}km',
+        'power_format': 'Power {state:3s}                  {source}',
+    }
+
+FORMAT = OFFICIAL_FORMAT
+USE_MBB_TIME = True
 
 class BinaryTools:
     '''
@@ -55,8 +74,21 @@ class LogFile:
 
     def __init__(self, file_path):
         with open(file_path, 'rb') as f:
-            m = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ)
-            self._data = bytearray(m)
+            self._data = bytearray(f.read())
+
+    def unescape_block(self, data):
+        start_offset = 0
+
+        escape_offset = data.find('\xfe')
+
+        while escape_offset != -1:
+            escape_offset += start_offset
+            data[escape_offset] = data[escape_offset] ^ data[escape_offset+1] - 1
+            data = data[0:escape_offset+1] + data[escape_offset + 2:]
+            start_offset = escape_offset + 1
+            escape_offset = data[start_offset:].find('\xfe')
+
+        return data
 
     def index(self, sequence):
         return self._data.index(sequence)
@@ -69,24 +101,39 @@ class LogFile:
         return self._data[start_address+offset:start_address+length+offset]
 
 
-def parse_entry(log, address):
+def parse_entry(log, address, entry_num):
     '''
     Parse an individual entry from a LogFile into a human readable form
     '''
     header = log.unpack('char', 0x0, offset=address)
     if header != b'\xb2':
         raise ValueError('Invalid entry header byte')
+
     length = log.unpack('uint8', 0x1, offset=address)
-    message_type = log.unpack('uint8', 0x2, offset=address)
-    timestamp = log.unpack('uint32', 0x3, offset=address)
-    message = log.extract(0x7, length - 0x7, offset=address)
+
+    unescaped_block = log.unescape_block(log.extract(0x02, length-2, offset=address))
+
+    message_type = BinaryTools.unpack('uint8', unescaped_block, 0x00)
+    timestamp = BinaryTools.unpack('uint32', unescaped_block, 0x01)
+    message = unescaped_block[0x05:]
 
     def debug_message(x):
         return BinaryTools.unpack('char', x, 0x0, count=len(x) - 1)
 
+    def board_status(x):
+        fields = {
+            'state': BinaryTools.unpack('uint8', x, 0x00)
+        }
+
+        condition = 'Unknown'
+        if fields['state'] == 0x04:
+            condition = 'Software'
+
+        return 'Board Reset                {0}'.format(condition)
+
     def key_state(x):
         fields = {
-            'state': 'on' if BinaryTools.unpack('bool', x, 0x0) else 'off'
+            'state': 'On ' if BinaryTools.unpack('bool', x, 0x0) else 'Off'
         }
         return 'Key {state}'.format(**fields)
 
@@ -94,100 +141,239 @@ def parse_entry(log, address):
         fields = {
             'module': BinaryTools.unpack('uint8', x, 0x0)
         }
-        return 'Module {module:02} CAN link up'.format(**fields)
+        return 'Module {module:02} CAN Link Up'.format(**fields)
+
+    def battery_can_link_down(x):
+        fields = {
+            'module': BinaryTools.unpack('uint8', x, 0x0)
+        }
+        return 'Module {module:02} CAN Link Down'.format(**fields)
 
     def sevcon_can_link_up(x):
-        return 'Sevcon CAN link up'
+        return 'Sevcon CAN Link Up'
 
-    def can_ack_error(x):
-        return 'CAN ACK error'
+    def sevcon_can_link_down(x):
+        return 'Sevcon CAN Link Down'
 
     def run_status(x):
+        mod_translate = {
+            0x00: '00',
+            0x01: '10',
+            0x02: '01',
+            0x03: '11',
+        }
+
         fields = {
             'pack_temp_hi': BinaryTools.unpack('uint8', x, 0x0),
             'pack_temp_low': BinaryTools.unpack('uint8', x, 0x1),
             'soc': BinaryTools.unpack('uint16', x, 0x2),
             'pack_voltage': BinaryTools.unpack('uint32', x, 0x4) / 1000.0,
-            'motor_temp': BinaryTools.unpack('uint8', x, 0x8),
-            'controller_temp': BinaryTools.unpack('uint8', x, 0xa),
+            'motor_temp': BinaryTools.unpack('int16', x, 0x8),
+            'controller_temp': BinaryTools.unpack('int16', x, 0xa),
             'rpm': BinaryTools.unpack('uint16', x, 0xc),
-            'battery_current': BinaryTools.unpack('uint8', x, 0x10),
-            'motor_current': BinaryTools.unpack('uint8', x, 0x13),
+            'battery_current': BinaryTools.unpack('int16', x, 0x10),
+            'mods': mod_translate.get(BinaryTools.unpack('uint8', x, 0x12), "Unknown"),
+            'motor_current': BinaryTools.unpack('int16', x, 0x13),
+            'ambient_temp': BinaryTools.unpack('int16', x, 0x15),
+            'odometer': BinaryTools.unpack('uint32', x, 0x17),
         }
-        return 'Riding - ' \
-            'pack: h {pack_temp_hi}C, l {pack_temp_low}C, {pack_voltage:03.3f}V, {soc}% SOC | ' \
-            'motor: {motor_temp}C, {rpm}rpm | '\
-            'controller: {controller_temp}C, | '\
-            'power delivery: battery {battery_current}A, motor {motor_current}A'.format(**fields)
+        return FORMAT['riding_format'].format(**fields)
+
+    def calex_status(x):
+        states = {
+            0x00: 'Disconnected',
+            0x01: 'Connected',
+        }
+
+        size = {
+            0x00: "720W",
+            0x01: "1200W",
+        }
+        module_name = {
+            0x00: 'Calex 720W',
+            0x01: 'Calex 1200W',
+            0x02: 'External Chg 0',
+            0x03: 'External Chg 1',
+        }
+
+        fields = {
+            'module': BinaryTools.unpack('uint8', x, 0x0),
+            'state': states.get(BinaryTools.unpack('uint8', x, 0x1)),
+            'module_name': module_name.get(BinaryTools.unpack('uint8', x, 0x0), "Unknown")
+        }
+
+        return '{module_name} Charger {module} {state:13s}'.format(**fields)
+
+    def charging_status(x):
+#        s = "XXXXXXXXXXX %x" % (message_type) + " " + ' '.join(['0x{:02x}'.format(c) for c in x])
+        fields = {
+            'pack_temp_hi': BinaryTools.unpack('uint8', x, 0x00),
+            'pack_temp_low': BinaryTools.unpack('uint8', x, 0x01),
+            'soc': BinaryTools.unpack('uint16', x, 0x02),
+            'pack_voltage': BinaryTools.unpack('uint32', x, 0x4) / 1000.0,
+            'battery_current': BinaryTools.unpack('int8', x, 0x08),
+            'mods': BinaryTools.unpack('uint8', x, 0x0c),
+            'ambient_temp': BinaryTools.unpack('int8', x, 0x0d),
+        }
+
+        return 'Charging                   PackTemp: h {pack_temp_hi}C, l {pack_temp_low}C, AmbTemp: {ambient_temp}C, PackSOC:{soc:3d}%, Vpack:{pack_voltage:7.3f}V, BattAmps: {battery_current:3d}, Mods: {mods:02b}, MbbChgEn: Yes, BmsChgEn: No'.format(**fields)
+
+    def sevcon_status(x):
+        cause = {
+            0x4681: "Preop",
+            0x4884: "Sequence Fault",
+            0x4981: "Throttle Fault",
+        }
+
+        fields = {
+            'code': BinaryTools.unpack('uint16', x, 0x00),
+            'reg': BinaryTools.unpack('uint8', x, 0x04),
+            'sevcon_code': BinaryTools.unpack('uint16', x, 0x02),
+            'data': ' '.join(['{:02X}'.format(c) for c in x[5:]]),
+            'cause': cause.get(BinaryTools.unpack('uint16', x, 0x02), "Unknown!"),
+        }
+
+        return 'SEVCON CAN EMCY Frame      Error Code: 0x{code:04X}, Error Reg: 0x{reg:02X}, Sevcon Error Code: 0x{sevcon_code:04X}, Data: {data}, {cause}'.format(**fields)
 
     def battery_status(x):
         states = {
-            0x00: 'disconnecting',
-            0x01: 'connecting',
-            0x02: 'registered'
+            0x00: 'Opening Contactor',
+            0x01: 'Closing Contactor',
+            0x02: 'Registered'
         }
 
         fields = {
-            'state': states.get(BinaryTools.unpack('uint8', x, 0x0)),
+            'state': states.get(BinaryTools.unpack('uint8', x, 0x0), "Unknown!"),
             'module': BinaryTools.unpack('uint8', x, 0x1),
             'modvolt': BinaryTools.unpack('uint32', x, 0x2) / 1000.0,
             'sysmax': BinaryTools.unpack('uint32', x, 0x6) / 1000.0,
-            'sysmin': BinaryTools.unpack('uint32', x, 0xa) / 1000.0
+            'sysmin': BinaryTools.unpack('uint32', x, 0xa) / 1000.0,
+            'vcap': BinaryTools.unpack('uint32', x, 0x0e) / 1000.0,
+            'batcurr': BinaryTools.unpack('int16', x, 0x12),
+            'serial': BinaryTools.unpack('char', x, 0x14, count=len(x[0x14:])),
         }
-        return 'Battery module {module:02} {state} ('\
-            'module: {modvolt:03.3f}V, '\
-            'system max: {sysmax:03.3f}V, '\
-            'system min: {sysmin:03.3f}V'\
-            ')'.format(**fields)
+
+        # Ensuring the serial is printable
+        fields['serial'] = filter(lambda x: x in string.printable, fields['serial'])
+
+        if BinaryTools.unpack('uint8', x, 0x0) == 0x00:
+            return 'Module {module:02} {state}  vmod: {modvolt:7.3f}V, batt curr: {batcurr:3.0f}A'.format(**fields)
+        elif BinaryTools.unpack('uint8', x, 0x00) == 0x01:
+            fields['diff'] = fields['sysmax'] - fields['sysmin']
+            fields['prechg'] = int(fields['vcap'] * 100 / fields['modvolt'])
+            return 'Module {module:02} {state}  vmod: {modvolt:7.3f}V, maxsys: {sysmax:7.3f}V, minsys: {sysmin:7.3f}V, diff: {diff:0.03f}V, vcap: {vcap:6.3f}V, prechg: {prechg}%'.format(**fields)
+        else:
+            return 'Module {module:02} {state}     serial: {serial},  vmod: {modvolt:3.3f}V'.format(**fields)
 
     def power_state(x):
         sources = {
-            0x01: 'key switch',
-            0x04: 'onboard charger'
+            0x01: 'Key Switch',
+            0x03: 'Ext Charger 1',
+            0x04: 'Onboard Charger',
         }
 
         fields = {
-            'state': 'on' if BinaryTools.unpack('bool', x, 0x0) else 'off',
-            'source': sources.get(BinaryTools.unpack('uint8', x, 0x1))
+            'state': 'On' if BinaryTools.unpack('bool', x, 0x0) else 'Off',
+            'source': sources.get(BinaryTools.unpack('uint8', x, 0x1), 'Unknown')
         }
 
-        return 'Power {state} ({source})'.format(**fields)
+        return FORMAT['power_format'].format(**fields)
 
     def sevcon_power_state(x):
         is_on = BinaryTools.unpack('bool', x, 0x0)
-        return 'Sevcon power {}'.format('on' if is_on else 'off')
+        return 'Sevcon {}'.format('Turned On' if is_on else 'Turned Off')
+
+    def show_bluetooth_state(x):
+        return 'BT RX buffer reset'
 
     def battery_discharge_current_limited(x):
-        limit = BinaryTools.unpack('uint16', x, 0x0)
-        return 'Battery discharge current limited to {}A'.format(limit)
+#        return "XXXXXXXXXXX %x" % (message_type) + " " + ' '.join(['0x{:02x}'.format(c) for c in x])
+        fields = {
+            'limit': BinaryTools.unpack('uint16', x, 0x00),
+            'min_cell': BinaryTools.unpack('uint16', x, 0x02),
+            'temp': BinaryTools.unpack('uint8', x, 0x04),
+            'max_amp': BinaryTools.unpack('uint16', x, 0x05),
+        }
+
+        fields['percent'] = fields['limit'] * 100 / fields['max_amp']
+
+        return 'Batt Dischg Cur Limited    {limit} A ({percent}%), MinCell: {min_cell}mV, MaxPackTemp: {temp}C'.format(**fields)
+
+    def low_chassis_isolation(x):
+        fields = {
+            'kohms': BinaryTools.unpack('uint32', x, 0x00),
+            'cell': BinaryTools.unpack('uint8', x, 0x04),
+        }
+        return 'Low Chassis Isolation      {kohms} KOhms to cell {cell}'.format(**fields)
+
+    def precharge_decay_too_steep(x):
+        return 'Precharge Decay Too Steep. Restarting Sevcon.'
+
+    def disarmed_status(x):
+        fields = {
+            'pack_temp_hi': BinaryTools.unpack('uint8', x, 0x0),
+            'pack_temp_low': BinaryTools.unpack('uint8', x, 0x1),
+            'soc': BinaryTools.unpack('uint16', x, 0x2),
+            'pack_voltage': BinaryTools.unpack('uint32', x, 0x4) / 1000.0,
+            'motor_temp': BinaryTools.unpack('int16', x, 0x8),
+            'controller_temp': BinaryTools.unpack('int16', x, 0xa),
+            'rpm': BinaryTools.unpack('uint16', x, 0xc),
+            'battery_current': BinaryTools.unpack('uint8', x, 0x10),
+            'mods': BinaryTools.unpack('uint8', x, 0x12),
+            'motor_current': BinaryTools.unpack('int8', x, 0x13),
+            'ambient_temp': BinaryTools.unpack('int16', x, 0x15),
+            'odometer': BinaryTools.unpack('uint32', x, 0x17),
+        }
+        return FORMAT['disarmed_format'].format(**fields)
 
     def battery_contactor_closed(x):
         module = BinaryTools.unpack('uint8', x, 0x0)
         return 'Battery module {:02} contactor closed'.format(module)
 
     def unhandled_entry_format(x):
-        return ' '.join(['0x{:02x}'.format(c) for c in x])
+        return "(%x) " % (message_type) + ' '.join(['0x{:02x}'.format(c) for c in x])
 
     parsers = {
+        0x01: board_status,
         0x09: key_state,
         0x28: battery_can_link_up,
+        0x29: battery_can_link_down,
         0x2a: sevcon_can_link_up,
-        0x2b: can_ack_error,
+        0x2b: sevcon_can_link_down,
         0x2c: run_status,
+        0x2d: charging_status,
+        0x2f: sevcon_status,
+        0x30: calex_status,
         0x33: battery_status,
         0x34: power_state,
         0x36: sevcon_power_state,
+        0x38: show_bluetooth_state,
         0x39: battery_discharge_current_limited,
+        0x3a: low_chassis_isolation,
+        0x3b: precharge_decay_too_steep,
+        0x3c: disarmed_status,
         0x3d: battery_contactor_closed,
         0xfd: debug_message
     }
     entry_parser = parsers.get(message_type, unhandled_entry_format)
 
-    entry = {
-        # There's some odd entries in our time field occasional, filter them
-        'time': localtime(timestamp) if timestamp > 0xfff else None,
-        'message': entry_parser(message)
-    }
+    try:
+        entry = {
+            'message': entry_parser(message)
+        }
+    except:
+        entry = {
+            'message': "Exception caught: " + unhandled_entry_format(message)
+        }
+
+    if timestamp > 0xfff:
+        if USE_MBB_TIME:
+            # The output from the MBB (via serial port) lists time as GMT-7, so we should adjust
+            entry['time'] = strftime(FORMAT['time_format'], gmtime(timestamp - 7*60*60))
+        else:
+            entry['time'] = strftime(FORMAT['time_format'], localtime(timestamp))
+    else:
+        entry['time'] = str(timestamp)
 
     return (length, entry)
 
@@ -221,19 +407,23 @@ def parse_log(bin_file, output):
         for k, v in sys_info.items():
             f.write('{0:18} {1}\n'.format(k, v))
         f.write('\n')
-        f.write('---\n')
+
+        # This conforms to the output of the MBB log
+        f.write('Printing {0} of {0} log entries..\n'.format(entries_count))
         f.write('\n')
+        f.write(' Entry    Time of Log            Event                      Conditions\n')
+        f.write('+--------+----------------------+--------------------------+----------------------------------\n')
 
         read_pos = entries_start
         for entry_num in range(entries_count):
-            (length, entry) = parse_entry(log, read_pos)
+            (length, entry) = parse_entry(log, read_pos, entry_num+1)
 
             fields = {
                 'entry': entry_num + 1,
-                'time': strftime('%Y-%m-%d %H:%M:%S', entry['time']) if entry['time'] else '',
+                'time': entry['time'],
                 'message': entry['message']
             }
-            f.write('{entry:05d}  {time:19s}  {message}\n'.format(**fields))
+            f.write(FORMAT['logline'].format(**fields))
 
             read_pos += length
 

--- a/zero_log_parser.py
+++ b/zero_log_parser.py
@@ -205,7 +205,7 @@ def parse_log(bin_file, output):
     sys_info['VIN'] = log.unpack('char', 0x240, count=17)
     sys_info['Firmware rev.'] = log.unpack('uint16', 0x27b)
     sys_info['Board rev.'] = log.unpack('uint16', 0x27d)
-    sys_info['Model'] = log.unpack('char', 0x27f, count=2)
+    sys_info['Model'] = log.unpack('char', 0x27f, count=3)
 
     entries_header_idx = log.index(b'\xa2\xa2\xa2\xa2')
     entries_end = log.unpack('uint32', 0x4, offset=entries_header_idx)


### PR DESCRIPTION
I've updated your code to support a bunch more messages that I was able to identify by comparing the output of your utility to the output I got from the diagnostic serial port. Correspondingly I've also changed some of your strings to match the output from the serial port - to make it easier to 'diff' the two outputs and find differences. Likewise the time format (and timezone) has been changed to match the output from the bike (which I think is Californian time?) This can be changed by setting the USE_MBB_TIME global - though thinking about it, it should probably be made optional via a command line argument.

One of the more major issues I've found is that the byte stream obtained via the bluetooth comms appears to encode some values in a strange way. I've been able to characterise this and fix it - this should hopefully fix the weirdness you might have found with timestamps or current values.

I've also extended the search string for the model number to three characters - to correctly detect my FXS - I hope this doesn't affect the searching of two character models.
