### PR TITLE
To deal with ValueError('Invalid entry header byte')

### DIFF
--- a/zero_log_parser.py
+++ b/zero_log_parser.py
@@ -91,6 +91,16 @@ class LogFile:
     def raw(self):
         return bytearray(self._data)
 
+def align_entry(log_data, address):
+    match = False
+    while not match:
+        header = BinaryTools.unpack('char', log_data, 0x0, offset=address)
+        if header != b'\xb2':
+            address += 1
+        else:
+            match=True
+    print "Skipped %d bytes for alignment" % address
+    return address
 
 def parse_entry(log_data, address):
     '''
@@ -536,7 +546,7 @@ def parse_log(bin_file, output):
         f.write(' Entry    Time of Log            Event                      Conditions\n')
         f.write('+--------+----------------------+--------------------------+----------------------------------\n')
 
-        read_pos = 0
+        read_pos = align_entry(event_log,0)
         for entry_num in range(entries_count):
             (length, entry) = parse_entry(event_log, read_pos)
 


### PR DESCRIPTION
Added code to skip bytes that don't match the header signature before entering the parse loop.

I have not yet added code to deal with the overrun at the end of the parse loop caused by loosing the log entry at the head. Messy but despite the exception you get your log file.